### PR TITLE
Updated index.js to toggle overlayMapTypes on and off.

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,8 +40,8 @@ function initAutocomplete() {
     if(document.getElementById('weather').checked)
       {map.overlayMapTypes.insertAt(0, myMapType);}
     else
-      // This line is not working
-      {map.overlayMapTypes.insertAt(null);}
+      // .clear() works like a champ!
+      {map.overlayMapTypes.clear();}
     });
 
   // Create the search box and link it to the UI element.


### PR DESCRIPTION
Updated index.js to toggle overlayMapTypes on and off.  This is the proper syntax:
{map.overlayMapTypes.clear();} for turning the cloud layer off